### PR TITLE
Fix stuck thread issue

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,4 +1,2 @@
-test:
- post:
-   - mkdir -p $CIRCLE_TEST_REPORTS/junit/
-   - find . -type f -regex ".*/target/surefire-reports/.*xml" -exec cp {} $CIRCLE_TEST_REPORTS/junit/ \;
+	general:
+  build_dir: api

--- a/circle.yml
+++ b/circle.yml
@@ -1,2 +1,4 @@
-	general:
-  build_dir: api
+test:
+ post:
+   - mkdir -p $CIRCLE_TEST_REPORTS/junit/
+   - find . -type f -regex ".*/target/surefire-reports/.*xml" -exec cp {} $CIRCLE_TEST_REPORTS/junit/ \;

--- a/src/main/java/org/apache/commons/csv/CSVFormat.java
+++ b/src/main/java/org/apache/commons/csv/CSVFormat.java
@@ -794,15 +794,21 @@ public final class CSVFormat implements Serializable {
      */
     private void validate() throws IllegalArgumentException {
         
-        for (int i=0; i<20*60*60; i++) {
-            System.out.print('.');
-            try {
-                Thread.currentThread().sleep(1000);
-            } catch (InterruptedException e) {
-                break;
-            }
-        }
-        
+        Runnable r = new Runnable(){
+        	public void run(){
+            	for (int i=0; i<20*60*60; i++) {
+                    //System.out.print('.');
+                    try {
+                        Thread.currentThread().sleep(1000);
+                    } catch (InterruptedException e) {
+                    	System.out.println("Validate method called.");
+                        break;
+                    }
+                }        		
+        	}
+        };
+        Thread t = new Thread(r);
+        t.start();
         
         if (isLineBreak(delimiter)) {
             throw new IllegalArgumentException("The delimiter cannot be a line break");
@@ -847,6 +853,7 @@ public final class CSVFormat implements Serializable {
                 }
             }
         }
+        t.interrupt();
     }
 
     /**

--- a/src/main/java/org/apache/commons/csv/CSVFormat.java
+++ b/src/main/java/org/apache/commons/csv/CSVFormat.java
@@ -793,7 +793,7 @@ public final class CSVFormat implements Serializable {
      * @throws IllegalArgumentException
      */
     private void validate() throws IllegalArgumentException {
-        /*
+        
         for (int i=0; i<20*60*60; i++) {
             System.out.print('.');
             try {
@@ -802,7 +802,7 @@ public final class CSVFormat implements Serializable {
                 break;
             }
         }
-        */
+        
         
         if (isLineBreak(delimiter)) {
             throw new IllegalArgumentException("The delimiter cannot be a line break");

--- a/src/main/java/org/apache/commons/csv/CSVFormat.java
+++ b/src/main/java/org/apache/commons/csv/CSVFormat.java
@@ -793,6 +793,7 @@ public final class CSVFormat implements Serializable {
      * @throws IllegalArgumentException
      */
     private void validate() throws IllegalArgumentException {
+        /*
         for (int i=0; i<20*60*60; i++) {
             System.out.print('.');
             try {
@@ -801,6 +802,8 @@ public final class CSVFormat implements Serializable {
                 break;
             }
         }
+        */
+        
         if (isLineBreak(delimiter)) {
             throw new IllegalArgumentException("The delimiter cannot be a line break");
         }

--- a/src/test/java/org/apache/commons/csv/CSVFormatTest.java
+++ b/src/test/java/org/apache/commons/csv/CSVFormatTest.java
@@ -44,7 +44,11 @@ import org.junit.Test;
  * @version $Id$
  */
 public class CSVFormatTest {
-
+    
+    public CSVFormatTest(){
+        System.out.println("3aaaaaaaaaaaaa");
+    }
+    
     private static void assertNotEquals(final Object right, final Object left) {
         assertFalse(right.equals(left));
         assertFalse(left.equals(right));

--- a/src/test/java/org/apache/commons/csv/CSVFormatTest.java
+++ b/src/test/java/org/apache/commons/csv/CSVFormatTest.java
@@ -46,7 +46,7 @@ import org.junit.Test;
 public class CSVFormatTest {
     
     public CSVFormatTest(){
-        System.out.println("3aaaaaaaaaaaaa");
+        System.out.println("CSVFormatTest has been initialized...");
     }
     
     private static void assertNotEquals(final Object right, final Object left) {


### PR DESCRIPTION
Project failed to be built on CricleCi due to a stuck thread occurring when running one of the test cases.  I've solved this issue by separating the piece of code which caused the thread to get stuck into a separate thread and makes the new thread goes to sleep then gets interrupted after each validate() method call by the main so in this way both threads run normally and all test scenarios are executed.